### PR TITLE
Add mergePDFs option to create etch packet

### DIFF
--- a/src/Anvil/Payloads/Request/CreateEtchPacket.cs
+++ b/src/Anvil/Payloads/Request/CreateEtchPacket.cs
@@ -1,4 +1,5 @@
-using System.Text.Json.Serialization;
+// Required to use `JSONProperty`. We don't want the built-in .NET version.
+using Newtonsoft.Json;
 
 using Anvil.Payloads.Request.Types;
 
@@ -16,13 +17,13 @@ namespace Anvil.Payloads.Request
         public string? ReplyToName { get; set; }
         public string? ReplyToEmail { get; set; }
 
-        [JsonPropertyName("mergePDFs")]
+        [JsonProperty("mergePDFs")]
         public bool? MergePdfs { get; set; }
 
         public EtchSigner[]? Signers { get; set; }
         public object? Data { get; set; }
 
-        [JsonPropertyName("webhookURL")]
+        [JsonProperty("webhookURL")]
         public string? WebhookUrl { get; set; }
 
     }

--- a/src/Anvil/Payloads/Request/CreateEtchPacket.cs
+++ b/src/Anvil/Payloads/Request/CreateEtchPacket.cs
@@ -16,10 +16,13 @@ namespace Anvil.Payloads.Request
         public string? ReplyToName { get; set; }
         public string? ReplyToEmail { get; set; }
 
+        [JsonPropertyName("mergePDFs")]
+        public bool? MergePdfs { get; set; }
+
         public EtchSigner[]? Signers { get; set; }
         public object? Data { get; set; }
 
-        [JsonPropertyName("webhookURL")] 
+        [JsonPropertyName("webhookURL")]
         public string? WebhookUrl { get; set; }
 
     }

--- a/src/Anvil/Payloads/Request/GeneratePdf.cs
+++ b/src/Anvil/Payloads/Request/GeneratePdf.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 using Anvil.Payloads.Request.Types;

--- a/src/Anvil/Payloads/Request/Types/EtchCastRef.cs
+++ b/src/Anvil/Payloads/Request/Types/EtchCastRef.cs
@@ -1,12 +1,13 @@
-using System.Text.Json.Serialization;
+// Required to use `JSONProperty`. We don't want the built-in .NET version.
+using Newtonsoft.Json;
 
 namespace Anvil.Payloads.Request.Types
 {
     public class EtchCastRef : IEtchPacketAttachable
     {
         public string? Id { get; set; }
-        
-        [JsonPropertyName("castEid")] 
+
+        [JsonProperty("castEid")]
         public string? CastEid { get; set; }
     }
 }

--- a/src/Anvil/Payloads/Request/Types/EtchSigner.cs
+++ b/src/Anvil/Payloads/Request/Types/EtchSigner.cs
@@ -1,5 +1,7 @@
 using System;
-using System.Text.Json.Serialization;
+
+// Required to use `JSONProperty`. We don't want the built-in .NET version.
+using Newtonsoft.Json;
 
 namespace Anvil.Payloads.Request.Types
 {
@@ -29,7 +31,7 @@ namespace Anvil.Payloads.Request.Types
         }
 
         public int? RoutingOrder { get; set; }
-        [JsonPropertyName("redirectURL")]
+        [JsonProperty("redirectURL")]
         public string? RedirectUrl { get; set; }
         public bool? AcceptEachField { get; set; }
         public string[]? EnableEmails { get; set; }

--- a/src/Anvil/Payloads/Request/Types/Rect.cs
+++ b/src/Anvil/Payloads/Request/Types/Rect.cs
@@ -1,16 +1,17 @@
-using System.Text.Json.Serialization;
+// Required to use `JSONProperty`. We don't want the built-in .NET version.
+using Newtonsoft.Json;
 
 namespace Anvil.Payloads.Request.Types
 {
     public class Rect
     {
-        [JsonPropertyName("x")]
+        [JsonProperty("x")]
         public float? X { get; set; }
-        [JsonPropertyName("y")]
+        [JsonProperty("y")]
         public float? Y { get; set; }
-        [JsonPropertyName("width")]
+        [JsonProperty("width")]
         public float? Width { get; set; }
-        [JsonPropertyName("height")]
+        [JsonProperty("height")]
         public float? Height { get; set; }
     }
 }

--- a/src/Anvil/Queries/CreateEtchPacket.cs
+++ b/src/Anvil/Queries/CreateEtchPacket.cs
@@ -17,12 +17,14 @@ namespace Anvil.Queries
                 $signers: [JSON!],
                 $webhookURL: String,
                 $data: JSON,
+                $mergePDFs: Boolean,
             ) {{
                 createEtchPacket (
                     name: $name,
                     files: $files,
                     isDraft: $isDraft,
                     isTest: $isTest,
+                    mergePDFs: $mergePDFs,
                     signatureEmailSubject: $signatureEmailSubject,
                     signatureEmailBody: $signatureEmailBody,
                     signatureProvider: $signatureProvider,
@@ -31,7 +33,7 @@ namespace Anvil.Queries
                     replyToName: $replyToName,
                     replyToEmail: $replyToEmail,
                     webhookURL: $webhookURL,
-                    data: $data
+                    data: $data,
                 )
                 {0}
             }}


### PR DESCRIPTION
* Adds `mergePDFs` option to `CreateEtchPacket`
* Fixes issue where property mappings weren't working (i.e. default of `mergePdfs` -> `mergePDFs` when serializing) 