### PR TITLE
Add .anvil/marketing.yml for marketing-site language pages

### DIFF
--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,14 +1,8 @@
-# Language declaration for anvilco/marketing-site. Read at build time to source
-# the C# / .NET SDK page from this repo. `supported` is omitted so it derives
-# from repo visibility (public = live). Examples are omitted: this repo keeps a
-# single combined Example.cs rather than per-product files, so the marketing
-# site's committed content stands until per-product examples exist.
 products:
   - generate
   - fill
   - sign
 languages:
-  - key: csharp
+  - key: csharp-dotnet
     label: "C# & .NET"
     shortLabel: "C#"
-    slug: csharp-dotnet

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,0 +1,13 @@
+# Language declaration for anvilco/marketing-site. Read at build time to source
+# the C# / .NET SDK page from this repo. `supported` is omitted so it derives
+# from repo visibility (public = live). Examples are omitted: this repo keeps a
+# single combined Example.cs rather than per-product files, so the marketing
+# site's committed content stands until per-product examples exist.
+products:
+  - generate
+  - fill
+  - sign
+languages:
+  - key: csharp
+    label: "C# & .NET"
+    slug: csharp-dotnet

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -10,4 +10,5 @@ products:
 languages:
   - key: csharp
     label: "C# & .NET"
+    shortLabel: "C#"
     slug: csharp-dotnet


### PR DESCRIPTION
Adds `.anvil/marketing.yml` so anvilco/marketing-site sources this repo's C# / .NET SDK page at build time (language identity and products) instead of hardcoding them in the marketing site.

`supported` is omitted so the marketing site derives live/coming-soon from this repo's visibility. Per-product `examples` are omitted because this repo keeps a single combined `Example.cs` rather than per-product files; the marketing site's committed content stands until per-product examples exist.

Related to anvilco/marketing-site#3505.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anvilco/codesmith/dotnet-anvil/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788559159&installation_model_id=8728&pr_number=20&repository=anvilco%2Fdotnet-anvil&return_to=https%3A%2F%2Fgithub.com%2Fanvilco%2Fdotnet-anvil%2Fpull%2F20&signature=783b9009daea38724f8d4d5bec745bd97aa5f40d1a68ed94dd681a1063196d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->