### PR TITLE
Slim marketing.yml to identity (drop derived products)

### DIFF
--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,7 +1,3 @@
-products:
-  - generate
-  - fill
-  - sign
 languages:
   - key: csharp-dotnet
     label: "C# & .NET"


### PR DESCRIPTION
Follow-up to #20. The marketing-site sourcing now derives each language's products by scanning the repo's `examples/` dir (marketing PR anvilco/marketing-site#3617), so the `products` array here is redundant. This trims `.anvil/marketing.yml` to identity only.
