### PR TITLE
Rename .anvil/marketing.yml to metadata.yml and declare language extension

### DIFF
--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,4 +1,0 @@
-languages:
-  - key: csharp-dotnet
-    label: "C# & .NET"
-    shortLabel: "C#"

--- a/.anvil/metadata.yml
+++ b/.anvil/metadata.yml
@@ -1,0 +1,5 @@
+languages:
+  - key: csharp-dotnet
+    label: "C# & .NET"
+    shortLabel: "C#"
+    extension: cs


### PR DESCRIPTION
Renames `.anvil/marketing.yml` to `.anvil/metadata.yml` and adds an `extension` to each language.

The marketing-site SDK-page sourcing now reads `.anvil/metadata.yml` (`marketing` was misleading for repo metadata) and figures out each language's example files from the repo by its declared `extension`, so nothing about languages is hardcoded on the marketing side (anvilco/marketing-site#3617).
